### PR TITLE
fix(example01): Fix all target dependency

### DIFF
--- a/example-01-pru-hello/Makefile
+++ b/example-01-pru-hello/Makefile
@@ -7,7 +7,7 @@ CFLAGS = --include_path=$(PRU_SWPKG)/include \
          --include_path=$(PRU_SWPKG)/include/j721e
 LDFLAGS = J721E_PRU9.cmd
 
-all: main-pru
+all: $(PRU_FW)
 
 main-pru.o: main-pru.c
 	$(CC) $(CFLAGS) $^ --output_file $@


### PR DESCRIPTION
ALl target dep should point to PRU_FW.
make debug-pru9 works, but not make (all).